### PR TITLE
Fixes for how LengthProviders provide lengths to variable size fields

### DIFF
--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -370,7 +370,7 @@ class DispatchTarget(BaseField):
         if self.length_provider is None:
             return None
         else:
-            return self.length_provider.getval()
+            return self.length_provider.get_adjusted_length()
 
     def getval(self):
         return self._value
@@ -578,7 +578,7 @@ class BaseVariableByteSequence(BaseField):
 
     @property
     def bytes_required(self):
-        return self.length_provider.getval()
+        return self.length_provider.get_adjusted_length()
 
     def pack(self, stream):
         sfmt = self.make_format(len(self._value))

--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -520,6 +520,12 @@ class ConditionalField(BaseField):
     def setval(self, value):
         return self.field.setval(value)
 
+    def associate_length_consumer(self, target_field):
+        self.field.associate_length_consumer(target_field)
+
+    def get_adjusted_length(self):
+        return self.field.get_adjusted_length()
+
 
 class Payload(BaseField):
     """Variable length raw (byte string) field


### PR DESCRIPTION
Currently, there are some inconsistencies where Payload() calls .get_adjusted_length(), while other field which use LengthProviders such as a DispatchTarget call .getval(). This causes problems when trying to configure a DispatchTarget to grab both the type and length from one field. This inconsistency also may have been causing problems where DispatchTarget did not properly respect a LengthField's multiplier attribute.

Additionally, there is currently not support for wrapping length-related fields in ConditionalFields. This pull request configures ConditionalFields to pass length requests through to the inner field to allow this functionality.