### PR TITLE
Functionality required for ZCL support

### DIFF
--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -719,13 +719,10 @@ class BaseStructField(BaseField):
         try:
             keep_bytes = getattr(self, 'KEEP_BYTES', None)
             if keep_bytes is not None:
-                if self.PACK_FORMAT[0] == "<":
-                    to_write = struct.pack(self.PACK_FORMAT, self._value)[:keep_bytes]
-                elif self.PACK_FORMAT[0] == ">":
+                if self.PACK_FORMAT[0] == b">"[0]:  # The element access makes this compatible with Python 2 and 3
                     to_write = struct.pack(self.PACK_FORMAT, self._value)[-keep_bytes:]
                 else:
-                    raise SuitcaseProgrammingError("When specifying KEEP_BYTES, \
-                    PACK_FORMAT must start with `>` or `<`")
+                    to_write = struct.pack(self.PACK_FORMAT, self._value)[:keep_bytes]
             else:
                 to_write = struct.pack(self.PACK_FORMAT, self._value)
         except struct.error as e:
@@ -734,14 +731,12 @@ class BaseStructField(BaseField):
 
     def unpack(self, data):
         value = 0
-        if self.UNPACK_FORMAT[0] == "<":
-            for i, byte in enumerate(struct.unpack(self.UNPACK_FORMAT, data)):
-                value |= (byte << (i * 8))
-        elif self.UNPACK_FORMAT[0] == ">":
+        if self.UNPACK_FORMAT[0] == b">"[0]:  # The element access makes this compatible with Python 2 and 3
             for i, byte in enumerate(reversed(struct.unpack(self.UNPACK_FORMAT, data))):
                 value |= (byte << (i * 8))
         else:
-            raise SuitcaseProgrammingError("UNPACK_FORMAT must start with `>` or `<`")
+            for i, byte in enumerate(struct.unpack(self.UNPACK_FORMAT, data)):
+                value |= (byte << (i * 8))
         self._value = value
 
 

--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -490,7 +490,7 @@ class TypeField(BaseField):
         target_key = self.type_field.getval()
         target_length = self.length_mapping.get(target_key, None)
         if target_length is None:
-            target_length = self.type_field.get(None, None)
+            target_length = self.length_mapping.get(None, None)
 
         return target_length
 
@@ -523,7 +523,7 @@ class TypeField(BaseField):
     def pack(self, stream):
         if self.length_value_provider is None:
             raise SuitcaseException("No length_provider added to this TypeField")
-        # This will throw an exception if the length is not correct
+        # This will throw a SuitcasePackException if the length is not correct
         self.length_value_provider()
 
         self.type_field.pack(stream)

--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -474,9 +474,8 @@ class TypeField(BaseField):
     integer value.  A TypeField can be pointed to by a variable
     length field and will fix that field's length.
 
-    :param type_field: The field providing the actual length value to
-        be used.  This field should return an integer value representing
-        the length (or a multiple of the length) as a return value
+    :param type_field: The field providing the type id that will
+        be used to lookup a length value
     :param length_mapping: This is a dictionary mapping type_field
         values to associated length values.
 

--- a/suitcase/structure.py
+++ b/suitcase/structure.py
@@ -56,11 +56,13 @@ class Packer(object):
                 checksum_data = self.crc_field.packed_checksum(data)
                 stream.write(checksum_data)
 
-    def unpack(self, data):
+    def unpack(self, data, trailing=False):
         stream = BytesIO(data)
         self.unpack_stream(stream)
         stream.tell()
-        if stream.tell() != len(data):
+        if trailing:
+            return stream
+        elif stream.tell() != len(data):
             raise SuitcaseParseError("Structure fully parsed but additional bytes remained.  Parsing "
                                      "consumed %d of %d bytes" %
                                      (stream.tell(), len(data)))
@@ -288,8 +290,8 @@ class Structure(object):
     def lookup_field_by_placeholder(self, placeholder):
         return self._placeholder_to_field[placeholder]
 
-    def unpack(self, data):
-        return self._packer.unpack(data)
+    def unpack(self, data, trailing=False):
+        return self._packer.unpack(data, trailing)
 
     def pack(self):
         return self._packer.pack()

--- a/suitcase/test/test_fields.py
+++ b/suitcase/test/test_fields.py
@@ -11,10 +11,12 @@ from suitcase.crc import crc16_ccitt, crc32
 from suitcase.exceptions import SuitcaseProgrammingError, SuitcasePackStructException, SuitcasePackException, \
     SuitcaseParseError
 from suitcase.fields import DependentField, LengthField, VariableRawPayload, \
-    Magic, BitField, BitBool, BitNum, UBInt8, UBInt16, UBInt24, UBInt32, UBInt64, \
-    SBInt8, SBInt16, SBInt32, SBInt64, ULInt8, ULInt16, ULInt32, ULInt64, SLInt8, \
-    SLInt16, SLInt32, SLInt64, ConditionalField, UBInt8Sequence, SBInt8Sequence, \
-    FieldProperty, DispatchField, DispatchTarget, CRCField, Payload
+    Magic, BitField, BitBool, BitNum, DispatchTarget, CRCField, Payload, \
+    UBInt8, UBInt16, UBInt24, UBInt32, UBInt40, UBInt48, UBInt56, UBInt64, \
+    SBInt8, SBInt16, SBInt24, SBInt32, SBInt40, SBInt48, SBInt56, SBInt64, \
+    ULInt8, ULInt16, ULInt24, ULInt32, ULInt40, ULInt48, ULInt56, ULInt64, \
+    SLInt8, SLInt16, SLInt24, SLInt32, SLInt40, SLInt48, SLInt56, SLInt64, \
+    ConditionalField, UBInt8Sequence, SBInt8Sequence, FieldProperty, DispatchField
 from suitcase.structure import Structure
 import struct
 
@@ -46,24 +48,39 @@ class SuperMessage(Structure):
     ubint16 = UBInt16()
     ubint24 = UBInt24()
     ubint32 = UBInt32()
+    ubint40 = UBInt40()
+    ubint48 = UBInt48()
+    ubint56 = UBInt56()
     ubint64 = UBInt64()
 
     # signed big endian
     sbint8 = SBInt8()
     sbint16 = SBInt16()
+    sbint24 = SBInt24()
     sbint32 = SBInt32()
+    sbint40 = SBInt40()
+    sbint48 = SBInt48()
+    sbint56 = SBInt56()
     sbint64 = SBInt64()
 
     # unsigned little endian
     ulint8 = ULInt8()
     ulint16 = ULInt16()
+    ulint24 = ULInt24()
     ulint32 = ULInt32()
+    ulint40 = ULInt40()
+    ulint48 = ULInt48()
+    ulint56 = ULInt56()
     ulint64 = ULInt64()
 
     # signed little endian
     slint8 = SLInt8()
     slint16 = SLInt16()
+    slint24 = SLInt24()
     slint32 = SLInt32()
+    slint40 = SLInt40()
+    slint48 = SLInt48()
+    slint56 = SLInt56()
     slint64 = SLInt64()
 
     # optional
@@ -118,25 +135,40 @@ class TestSuperField(unittest.TestCase):
         s.ubint16 = 0xAABB
         s.ubint24 = 0xAABBCC
         s.ubint32 = 0xAABBCCDD
+        s.ubint40 = 0xAABBCCDDEE
+        s.ubint48 = 0xAABBCCDDEEFF
+        s.ubint56 = 0xAABBCCDDEEFF00
         s.ubint64 = 0xAABBCCDDEEFF0011
 
-        s.sbint8 = -25
-        s.sbint16 = -312
-        s.sbint32 = -9570
-        s.sbint64 = -29349579
+        s.sbint8 = -100
+        s.sbint16 = -1000
+        s.sbint24 = -100000
+        s.sbint32 = -100000000
+        s.sbint40 = -10000000000
+        s.sbint48 = -10000000000000
+        s.sbint56 = -1000000000000000
+        s.sbint64 = -100000000000000000
 
         s.ulint8 = 0xAA
         s.ulint16 = 0xAABB
         s.ulint16_byte_string = b'\xAA\xBB'
         s.ulint16_value = 0xBBAA
 
+        s.ulint24 = 0xAABBCC
         s.ulint32 = 0xAABBCCDD
+        s.ulint40 = 0xAABBCCDDEE
+        s.ulint48 = 0xAABBCCDDEEFF
+        s.ulint56 = 0xAABBCCDDEEFF00
         s.ulint64 = 0xAABBCCDDEEFF0011
 
-        s.slint8 = -25
-        s.slint16 = -312
-        s.slint32 = -9570
-        s.slint64 = -29349579
+        s.slint8 = -100
+        s.slint16 = -1000
+        s.slint24 = -100000
+        s.slint32 = -100000000
+        s.slint40 = -10000000000
+        s.slint48 = -10000000000000
+        s.slint56 = -1000000000000000
+        s.slint64 = -100000000000000000
 
         s.optional_one = 1
         s.optional_two = 2


### PR DESCRIPTION
Added a FieldArray type which supports a variable number of another structure being embedded inside of it. Complex usage of this datatype necessitated a TypeField class which acts as a hybrid between a DispatchField/DispatchTarget and a LengthProvider, allowing for the length of a field to be given by a dictionary mapping. An example of why this is necessary can be seen [here](https://gist.github.com/rtzoeller/6dc3b0420fed92daa879).

Also added support for 24, 40, 48 and 56-bit integers.