### PR TITLE
docs, *.py: Fix spelling issues.

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -5,7 +5,7 @@ Packetized TCP Server and Client
 --------------------------------
 
 The following example shows an example of a protocol on TCP which has
-a length field and a payload of ``length`` bytes.  With suitcase, we
+a length field and a payload of ``length`` bytes.  With Suitcase, we
 only need to declare the basic structure of the message and we get a
 packer and a stream protocol handler out of the library with very
 little effort.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -10,8 +10,8 @@ Suitcase may be installed directly from `PyPi
 
     pip install suitcase
 
-This will install the library as well as any libraries dependended on
-by suitcase.
+This will install the library as well as any libraries depended on
+by Suitcase.
 
 The library is tested to work on the following python versions:
 
@@ -25,7 +25,7 @@ Data Modeling
 
 Suitcase provides a declarative syntax for recording the structure of
 the messages in your problem domain.  The first step is to understand
-those messages and convert each message layer into its correspdonding
+those messages and convert each message layer into its corresponding
 :class:`suitcase.structure.Structure` s and
 :class:`suitcase.fields.BaseField` s.
 
@@ -35,7 +35,7 @@ we wanted to parser and/or pack `DNS messsages
 <https://en.wikipedia.org/wiki/Domain_Name_System#DNS_message_format>`_.
 
 With just a little reading, we see that each DNS request and response
-has a common form which can be declared in suitcase with the following
+has a common form which can be declared in Suitcase with the following
 structure:
 
 .. literalinclude:: ../suitcase/examples/dns.py
@@ -55,9 +55,9 @@ Wikipedia page describing the same message.
 Using the Model
 ---------------
 
-The structure above provides suitcase with a wealth of information
+The structure above provides Suitcase with a wealth of information
 about the names, sizes, order, and relationship between different
-elements in a `DNSMessage`.  That knowledge is enough so that suitcase
+elements in a `DNSMessage`.  That knowledge is enough so that Suitcase
 can now both pack (generate bytes from and object) and parse (generate
 an object from bytes) for our message.
 
@@ -115,6 +115,6 @@ This generates a string like this::
 Working With Streams
 --------------------
 
-In addition to being able to parse and pack messages, suitcase also includes
-helpers that make working with stream-based protocols (e.g. TCP, Serial Port, etc).
+In addition to being able to parse and pack messages, Suitcase also includes
+helpers that make working with stream-based protocols (e.g. TCP, Serial Port, etc.)
 much easier.  See the API documentation for more details.

--- a/suitcase/crc.py
+++ b/suitcase/crc.py
@@ -89,7 +89,7 @@ CRC16_KERMIT_TAB = \
 
 
 def crc16_kermit(data, crc=0):
-    """Calculate/Updaet the Kermit CRC16 checksum for some data"""
+    """Calculate/Update the Kermit CRC16 checksum for some data"""
     tab = CRC16_KERMIT_TAB  # minor optimization (now in locals)
     for byte in six.iterbytes(data):
         tbl_idx = (crc ^ byte) & 0xff

--- a/suitcase/examples/client_server.py
+++ b/suitcase/examples/client_server.py
@@ -55,7 +55,7 @@ def client():
         request.payload = input
         s.sendall(request.pack())
 
-        # to handle asynchronous messages, this would be done asynchrnonously
+        # to handle asynchronous messages, this would be done asynchronously
         proto_handler.feed(s.recv(1024))
 
 

--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -60,7 +60,7 @@ class BaseField(object):
 
     :param instantiate: Create an actual instance instead of a placeholder
     :param parent: Specify the parent of this field (typically a Structure
-        instace).
+        instance).
 
     """
 
@@ -94,7 +94,7 @@ class CRCField(BaseField):
 
     CRC checks and calculation frequently work quite differently
     from other fields in a protocol and as such are treated differently
-    by the messag container.  In particular, a CRCField requires
+    by the message container.  In particular, a CRCField requires
     special steps at either the beginning or end of the message
     pack/unpack process.  For each CRCField, we specify the following:
 
@@ -159,7 +159,7 @@ class CRCField(BaseField):
                 recorded_checksum, actual_checksum, data)
 
     def packed_checksum(self, data):
-        """Given the data of the entire packet reutrn the checksum bytes"""
+        """Given the data of the entire packet return the checksum bytes"""
         self.field.setval(self.algo(data[self.start:self.end]))
         sio = BytesIO()
         self.field.pack(sio)
@@ -235,7 +235,7 @@ class FieldProperty(BaseField):
     :param onget: This is a function pointer to a function called to mutate
         the value returned on field access.  The function receives a single
         argument containing the value of the wrapped field.
-    :oaram onset: This is a functoin pointer to a function called to map
+    :oaram onset: This is a function pointer to a function called to map
         between the property and the underlying field.  The function takes
         a single parameter which is the value the property was set to.  It
         should return the value that the underlying field expects (or raise
@@ -669,7 +669,7 @@ class Payload(BaseField):
         self._value = data
 
 
-# keep for backwards compatability
+# keep for backwards compatibility
 VariableRawPayload = Payload
 
 
@@ -726,7 +726,7 @@ class DependentField(BaseField):
                 0x00: MyDependentMessage,
             })
 
-    :params name: The name of the field from the parent message that we
+    :param name: The name of the field from the parent message that we
         would like brought into our message namespace.
 
     """
@@ -919,10 +919,10 @@ class BaseStructField(BaseField):
     It is expected that this class will be subclassed and customized by
     defining ``FORMAT`` at the class level.  ``FORMAT`` is expected to
     be a format string that could be used with struct.pack/unpack.  It
-    should include endianess information.  If the ``FORMAT`` includes
+    should include endianness information.  If the ``FORMAT`` includes
     multiple elements, the default ``_unpack`` logic assumes that each
     element is a single byte and will OR these together.  To specialize
-    this, _unpack should be overriden.
+    this, _unpack should be overridden.
 
     """
 

--- a/suitcase/protocol.py
+++ b/suitcase/protocol.py
@@ -10,7 +10,7 @@ These protocols all wrap some base message schema and provide
 all the necessary hooks for pushing in a stream of bytes and
 getting out packets in the order they were found.  The protocol
 handlers will also provide notifications of error conditions
-(for instance, unexpected bytes or a bad checksum)
+(for instance, unexpected bytes or a bad checksum).
 
 """
 from functools import partial
@@ -27,12 +27,12 @@ class StreamProtocolHandler(object):
     IO on a serial port).
 
     Here's an example of what one usage might look like (very simple
-    appraoch for parsing a simple tcp protocol::
+    approach for parsing a simple TCP protocol::
 
 
         from suitcase.protocol import StreamProtocolHandler
         from suitcase.fields import LengthField, UBInt16, VariableRawPayload
-        from suitcase.struct import Structure
+        from suitcase.structure import Structure
         import socket
 
         class SimpleFramedMessage(Structure):
@@ -140,7 +140,7 @@ class StreamProtocolHandler(object):
             # behavior be?
             self.reset()
 
-        # callbacks are partials that are boudn to packet already.  We do
+        # callbacks are partials that are bound to packet already.  We do
         # this in order to separate out parsing activity (and error handling)
         # from the execution of callbacks.  Callbacks should not in any way
         # rely on the parsers position in the byte stream.
@@ -151,7 +151,7 @@ class StreamProtocolHandler(object):
         """Reset the internal state machine to a fresh state
 
         If the protocol in use does not properly handle cases of possible
-        desycnronization it might be necessary to issue a reset if bytes
+        de-synchronization it might be necessary to issue a reset if bytes
         are being received but no packets are coming out of the state
         machine.  A reset is issue internally whenever an unexpected exception
         is encountered while processing bytes from the stream.

--- a/suitcase/structure.py
+++ b/suitcase/structure.py
@@ -13,7 +13,7 @@ from six import BytesIO
 
 
 class ParseError(Exception):
-    """Exception raied when there is an error parsing"""
+    """Exception raised when there is an error parsing"""
 
 
 class Packer(object):


### PR DESCRIPTION
I also capitalized Suitcase in a few different places. I can roll those changes back if desired.