### PR TITLE
fields: Remove length-based optimization from ConditionalField.unpack

### DIFF
--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -613,8 +613,6 @@ class ConditionalField(BaseField):
             self.field.pack(stream)
 
     def unpack(self, data):
-        # length of data will be determined by bytes_required output value
-        # which is in turn determined by our condition evaluation
         if self.condition(self._parent):
             self.field.unpack(data)
 

--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -615,7 +615,7 @@ class ConditionalField(BaseField):
     def unpack(self, data):
         # length of data will be determined by bytes_required output value
         # which is in turn determined by our condition evaluation
-        if len(data) > 0:
+        if self.condition(self._parent):
             self.field.unpack(data)
 
     def getval(self):


### PR DESCRIPTION
Without this fix, it's currently not possible to dispatch to an empty structure
inside of a ConditionalField. This is due to an optimization in
ConditionalField.unpack() to prevent calling the condition function again.

Fixes #20 (or at least, the last problem brought up therein)