### PR TITLE
Fix conditional substructures

### DIFF
--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -617,6 +617,9 @@ class ConditionalField(BaseField):
             return self.field.unpack(data, **kwargs)
 
     def getval(self):
+        if not self.condition(self._parent):
+            return None
+
         return self.field.getval()
 
     def setval(self, value):

--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -612,9 +612,9 @@ class ConditionalField(BaseField):
         if self.condition(self._parent):
             self.field.pack(stream)
 
-    def unpack(self, data):
+    def unpack(self, data, **kwargs):
         if self.condition(self._parent):
-            self.field.unpack(data)
+            return self.field.unpack(data, **kwargs)
 
     def getval(self):
         return self.field.getval()


### PR DESCRIPTION
This fix mostly consists of making `Packer` recognize `SubstructureField` inside a conditional field, and making sure `ConditionalField.getval` returns None when the condition is not met. (Without the latter, it would always return the uninitialized substructure when accessed through the parent structure, e.g. `message.f2`)