### PR TITLE
Pass setval calls through SubstructureField to the contained Structure

### DIFF
--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -833,7 +833,7 @@ class SubstructureField(BaseField):
         return self._value.unpack(data, **kwargs)
 
     def setval(self, value):
-        if isinstance(value, suitcase.structure.Structure):
+        if value is None or isinstance(value, suitcase.structure.Structure):
             BaseField.setval(self, value)
         else:
             self._value.setval(value)

--- a/suitcase/fields.py
+++ b/suitcase/fields.py
@@ -8,6 +8,7 @@ import struct
 import six
 from suitcase.exceptions import SuitcaseChecksumException, SuitcaseProgrammingError, \
     SuitcaseParseError, SuitcaseException, SuitcasePackStructException
+import suitcase
 from six import BytesIO, StringIO
 
 
@@ -830,6 +831,12 @@ class SubstructureField(BaseField):
     def unpack(self, data, **kwargs):
         self._value = self.substructure()
         return self._value.unpack(data, **kwargs)
+
+    def setval(self, value):
+        if isinstance(value, suitcase.structure.Structure):
+            BaseField.setval(self, value)
+        else:
+            self._value.setval(value)
 
 
 class FieldArray(BaseField):


### PR DESCRIPTION
(If the value is a Structure, then replace the contained one.)

Currently, setting to a SubstructureField directly will replace the field with whatever you set, which can break the parent structure if what you set isn't a BaseField type.

    class PascalString16(Structure):
        length = LengthField(UBInt16())
        value = Payload(length)
    
     class Name(Structure):
        first = SubstructureField(PascalString16)
        last = SubstructureField(PascalString16)
    
    name = Name()
    name.first = 'bob' # Now name.first is a str instead of a PascalString16!

With this change, `name.first = 'bob'` will call `setval` on the `PascalString16` structure under `name.first`. This might not be a meaningful operation for many Structure types, but at least it will now raise an exception if setval hasn't been defined.