### PR TITLE
Calling dir() on a Structure includes Fields

### DIFF
--- a/suitcase/structure.py
+++ b/suitcase/structure.py
@@ -294,7 +294,7 @@ class Structure(object):
         return object.__setattr__(self, key, value)
 
     def __dir__(self):
-        return object.__dir__(self) + [str(k) for k, v in self._sorted_fields]
+        return dir(type(self)) + [str(k) for k, v in self._sorted_fields]
 
     def __iter__(self):
         return iter(self._sorted_fields)

--- a/suitcase/structure.py
+++ b/suitcase/structure.py
@@ -293,6 +293,9 @@ class Structure(object):
             return field.setval(value)
         return object.__setattr__(self, key, value)
 
+    def __dir__(self):
+        return object.__dir__(self) + [str(k) for k, v in self._sorted_fields]
+
     def __iter__(self):
         return iter(self._sorted_fields)
 

--- a/suitcase/test/test_fields.py
+++ b/suitcase/test/test_fields.py
@@ -1189,5 +1189,14 @@ class TestSubstructureField(unittest.TestCase):
         self.assertEqual(m.last.value, b"Doe")
         self.assertEqual(m.greedy, b"Hello World!")
 
+
+class TestDiscoverableFields(unittest.TestCase):
+    def test_dir(self):
+        m = PascalString16()
+        attrs = dir(m)
+        self.assertTrue("length" in attrs)
+        self.assertTrue("value" in attrs)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Based on [this](http://amir.rachum.com/blog/2016/10/05/python-dynamic-attributes/) blogpost, it may be desirable to have `Structure` implement `__dir__`, and add the dynamic fields to the returned list. This promotes field discovery when not looking at the structure implementation, and may help improve autocomplete in some cases.